### PR TITLE
Upgrade Joern Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,10 @@ RUN pip install -r ${TPF_HOME}/${REQUIREMENTS_FILE}
 
 COPY discovery ${DISCOVERY_HOME}
 RUN chmod +x ${DISCOVERY_HOME}/joern/joern/joern-install.sh
-RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/joern/ && ./joern-install.sh --version=v1.1.1512 --install-dir=/opt/joern'
+RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/joern/ && ./joern-install.sh --version=v1.1.1538 --install-dir=/opt/joern'
 
-#install js2cpg
-RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/js2cpg/; sbt stage'
+# install js2cpg
+# RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/js2cpg/; sbt stage'
 
 
 # ADD HERE COMMANDS USEFUL FOR OTHER DOCKER-COMPOSE SERVICES

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install -r ${TPF_HOME}/${REQUIREMENTS_FILE}
 
 COPY discovery ${DISCOVERY_HOME}
 RUN chmod +x ${DISCOVERY_HOME}/joern/joern/joern-install.sh
-RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/joern/ && ./joern-install.sh --version=v1.1.1269 --install-dir=/opt/joern'
+RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/joern/ && ./joern-install.sh --version=v1.1.1512 --install-dir=/opt/joern'
 
 #install js2cpg
 RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/js2cpg/; sbt stage'

--- a/discovery/joern/cpg-gen-config.yaml
+++ b/discovery/joern/cpg-gen-config.yaml
@@ -3,8 +3,8 @@ cpg_gen:
     installation_dir: "/php-cpg"
     command: "./php2cpg $SRC_DIR -o $BINARY_OUT -c main.conf bytecode 7"
   js:
-    installation_dir: "./discovery/joern/js2cpg"
-    command: "./js2cpg.sh $SRC_DIR --output $BINARY_OUT"
+    installation_dir: "/opt/joern/joern-cli/frontends/jssrc2cpg/bin/"
+    command: "./jssrc2cpg $SRC_DIR --output $BINARY_OUT"
   java:
     installation_dir: "/opt/joern/joern-cli/frontends/javasrc2cpg/bin/"
     command: "./javasrc2cpg $SRC_DIR --output $BINARY_OUT"


### PR DESCRIPTION
Referencing issue #43:

I've tested the framework with a more recent version of Joern, confirming that the global installation and manual discovery for JAVA patterns works as expected.

Java is the only language using the global joern installation and not a standalone frontend.
That being said, we could also think about upgrading the legacy js2cpg to the new and enhanced jssrc2cpg.
What do you think @SoheilKhodayari ? I could kick it off, but would need some testing from your side, I'd assume.

Feel free to merge @compaluca 