### PR TITLE
Refactor codeql docker

### DIFF
--- a/SAST/codeql/Dockerfile
+++ b/SAST/codeql/Dockerfile
@@ -7,12 +7,17 @@ FROM adoptopenjdk/openjdk11
 ARG TPF_HOME="/tp-framework"
 ARG CODEQL_INTERFACE_DIR="${TPF_HOME}/SAST/codeql"
 
+WORKDIR ${CODEQL_INTERFACE_DIR}
 
-COPY . ${CODEQL_INTERFACE_DIR}
+# copy necessary files for codeql
+COPY codeql_v2_9_2/ ${CODEQL_INTERFACE_DIR}/codeql_v2_9_2/
+COPY codeql_v2_13_1/ ${CODEQL_INTERFACE_DIR}/codeql_v2_13_1/
+COPY core/ ${CODEQL_INTERFACE_DIR}/core/
+COPY ./codeql-install.sh ${CODEQL_INTERFACE_DIR}
+COPY ./codeql-versions-list.yaml ${CODEQL_INTERFACE_DIR}
 
 RUN apt-get update
 RUN apt-get install wget
 
-#codeql installation
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64.tar.gz -O - | tar xz && mv yq_linux_amd64 /usr/bin/yq
+# codeql installation
 RUN ${CODEQL_INTERFACE_DIR}/codeql-install.sh ${CODEQL_INTERFACE_DIR}/codeql-versions-list.yaml

--- a/SAST/codeql/codeql-install.sh
+++ b/SAST/codeql/codeql-install.sh
@@ -1,14 +1,45 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 VERSION_LIST_FILE=$1
+CODEQL_DIR=/codeql
 
-mkdir ./codeql
+mkdir $CODEQL_DIR
 
-yq eval -M '{.versions}' $VERSION_LIST_FILE  | xargs -n2 | while read NAME LINK; do
+# Make sure the file contains a newline at the end
+echo -en '\n' >> "$VERSION_LIST_FILE"
 
-    wget $LINK
-    tar -xvzf ./codeql-bundle-linux64.tar.gz -C ./codeql && rm ./codeql-bundle-linux64.tar.gz
-    mv ./codeql/codeql ./codeql/$NAME
+name=""
+link=""
+# Read the VERSION_LIST_FILE line by line
+while IFS=: read -r key value; do
+  # Remove leading/trailing spaces from the key and value (remove " as well)
+  key=$(echo "$key" | xargs)
+  value=$(echo "$value" | xargs | tr -d '\"')
 
-    ./codeql/$NAME/codeql resolve languages
-    ./codeql/$NAME/codeql resolve qlpacks
-done
+  # Check if the line contains "link" or "name" field
+  if [[ "$key" == "link" ]]; then
+    link=$value
+  elif [[ "$key" == "name" ]]; then
+    name=$value
+  fi
+
+  # Check if both name and link are set
+  if [[ -n "$name" && -n "$link" ]]; then
+    # Download the codeql version using wget, extract it and move it to the codeql directory
+    echo "Downloading $name from $link"
+    wget -q "$link"
+    tar -xzf ./codeql-bundle-linux64.tar.gz -C "$CODEQL_DIR"
+    mv "$CODEQL_DIR/codeql" "$CODEQL_DIR/$name"
+
+    # setup codeql version
+    "$CODEQL_DIR/$name/codeql" resolve languages
+    "$CODEQL_DIR/$name/codeql" resolve qlpacks
+
+    # remove the downloaded .tar.gz
+    rm ./codeql-bundle-linux64.tar.gz
+
+    # Reset the variables for the next entry
+    name=""
+    link=""
+  fi
+done < "$VERSION_LIST_FILE"

--- a/SAST/codeql/codeql-versions-list.yaml
+++ b/SAST/codeql/codeql-versions-list.yaml
@@ -1,7 +1,7 @@
 versions:
-    #2_9_2:
-    #    name: "codeql_v2_9_2"
-    #    link: "https://github.com/github/codeql-action/releases/download/codeql-bundle-20220512/codeql-bundle-linux64.tar.gz"
+    2_9_2:
+       name: "codeql_v2_9_2"
+       link: "https://github.com/github/codeql-action/releases/download/codeql-bundle-20220512/codeql-bundle-linux64.tar.gz"
     2_13_1:
         name: "codeql_v2_13_1"
         link: "https://github.com/github/codeql-action/releases/download/codeql-bundle-20230428/codeql-bundle-linux64.tar.gz"

--- a/SAST/codeql/codeql-versions-list.yaml
+++ b/SAST/codeql/codeql-versions-list.yaml
@@ -1,7 +1,7 @@
 versions:
-    2_9_2:
-       name: "codeql_v2_9_2"
-       link: "https://github.com/github/codeql-action/releases/download/codeql-bundle-20220512/codeql-bundle-linux64.tar.gz"
+    # 2_9_2:
+    #    name: "codeql_v2_9_2"
+    #    link: "https://github.com/github/codeql-action/releases/download/codeql-bundle-20220512/codeql-bundle-linux64.tar.gz"
     2_13_1:
         name: "codeql_v2_13_1"
         link: "https://github.com/github/codeql-action/releases/download/codeql-bundle-20230428/codeql-bundle-linux64.tar.gz"

--- a/SAST/codeql/codeql_v2_13_1/codeql.py
+++ b/SAST/codeql/codeql_v2_13_1/codeql.py
@@ -2,7 +2,10 @@ from pathlib import Path
 import yaml
 from typing import Dict
 import sys
-sys.path.append('/tp-framework/SAST')
+
+DIR: Path = Path(__file__).parent.resolve()
+SAST_DIR: Path = DIR.parent.parent.resolve()
+sys.path.append(str(SAST_DIR))
 
 from codeql.core.codeql import CodeQL
 

--- a/SAST/codeql/codeql_v2_9_2/codeql.py
+++ b/SAST/codeql/codeql_v2_9_2/codeql.py
@@ -2,7 +2,10 @@ from pathlib import Path
 import yaml
 from typing import Dict
 import sys
-sys.path.append('/tp-framework/SAST')
+
+DIR: Path = Path(__file__).parent.resolve()
+SAST_DIR: Path = DIR.parent.parent.resolve()
+sys.path.append(str(SAST_DIR))
 
 from codeql.core.codeql import CodeQL
 

--- a/SAST/sast-config.yaml
+++ b/SAST/sast-config.yaml
@@ -4,9 +4,9 @@
 tools:
   codeql:
     version:
-      #2.9.2:
-      #  config: "./codeql/codeql_v2_9_2/config.yaml"
-      #  deploy: true
+      2.9.2:
+       config: "./codeql/codeql_v2_9_2/config.yaml"
+       deploy: true
       2.13.1:
         config: "./codeql/codeql_v2_13_1/config.yaml"
         deploy: true

--- a/SAST/sast-config.yaml
+++ b/SAST/sast-config.yaml
@@ -4,9 +4,9 @@
 tools:
   codeql:
     version:
-      2.9.2:
-       config: "./codeql/codeql_v2_9_2/config.yaml"
-       deploy: true
+      # 2.9.2:
+      #  config: "./codeql/codeql_v2_9_2/config.yaml"
+      #  deploy: true
       2.13.1:
         config: "./codeql/codeql_v2_13_1/config.yaml"
         deploy: true


### PR DESCRIPTION
Refactor the codeql docker image:

- codeql will be installed to `/codeql` now, while the interface is in `/SAST/codeql`.
- the `codeql-install.sh` does not need external dependencies to read the yaml file.
- the `codeql_v2_13_1/codeql.py` and  `codeql_v2_9_2/codeql.py` do not hardcode the path to the SAST directory.
- in the Dockerfile, all needed files are copied into the container explicitly

**Note**:
If you already have a working docker installation, you might need to remove the volumes ( `docker system prune --volumes`) to see the new changes.