### PR TITLE
CPG-only Discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 .pytest_cache
 venv
 tp_framework.egg-info/
+tp_framework/.metals/
+tp_framework/.vscode/
 coverage_html/
 .coverage
 htmlcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,18 +36,13 @@ ARG REQUIREMENTS_FILE
 COPY ${REQUIREMENTS_FILE} ${TPF_HOME}/${REQUIREMENTS_FILE}
 RUN pip install -r ${TPF_HOME}/${REQUIREMENTS_FILE}
 
-ARG JOERN_VERSION="v1.1.1538"
+ARG JOERN_VERSION="v1.2.1"
 RUN echo ${JOERN_VERSION}
 COPY discovery ${DISCOVERY_HOME}
 RUN chmod +x ${DISCOVERY_HOME}/joern/joern-install.sh
-RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/ && ./joern-install.sh --version=v1.1.1538 --install-dir=/opt/joern'
-
-# install js2cpg
-# RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/js2cpg/; sbt stage'
-
+RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/ && ./joern-install.sh --version=v1.2.1 --install-dir=/opt/joern'
 
 # ADD HERE COMMANDS USEFUL FOR OTHER DOCKER-COMPOSE SERVICES
-#
 
 ENV PYTHONPATH "${PYTHONPATH}:${TPF_HOME}/tp_framework"
 

--- a/tp_framework/cli/interface.py
+++ b/tp_framework/cli/interface.py
@@ -63,7 +63,8 @@ def add_pattern(pattern_dir: str, language: str, measure: bool, tools: list[Dict
 def run_discovery_for_pattern_list(src_dir: Path, pattern_id_list: list[int], language: str, itools: list[Dict],
                                    tp_lib_path: Path = Path(config.DEFAULT_TP_LIBRARY_ROOT_DIR).resolve(),
                                    output_dir: Path = Path(config.RESULT_DIR).resolve(),
-                                   ignore: bool = False):
+                                   ignore: bool = False,
+                                   cpg: str = None):
     print("Discovery for patterns started...")
     # Set output directory and logger
     build_name, disc_output_dir = utils.get_operation_build_name_and_dir(
@@ -72,7 +73,7 @@ def run_discovery_for_pattern_list(src_dir: Path, pattern_id_list: list[int], la
     #
     utils.check_tp_lib(tp_lib_path)
     d_res = discovery.discovery(Path(src_dir), pattern_id_list, tp_lib_path, itools, language, build_name,
-                                disc_output_dir, ignore=ignore)
+                                disc_output_dir, ignore=ignore, cpg=cpg)
     print("Discovery for patterns completed.")
     print(f"- results available here: {disc_output_dir}")
     print(f"- log file available here: {disc_output_dir / config.logfile}")

--- a/tp_framework/cli/tpf_commands.py
+++ b/tp_framework/cli/tpf_commands.py
@@ -214,6 +214,12 @@ class DiscoveryPatterns(Command):
             help="Path to discovery target folder"
         )
         discovery_parser.add_argument(
+            "-c", "--cpg",
+            dest="cpg_existing",
+            type=str,
+            help="Specify an already existing CPG in TARGET_DIR instead of letting the framework generate a new one."
+        )
+        discovery_parser.add_argument(
             "-i", "--ignore-measurements",
             action="store_true",
             default=False,
@@ -254,6 +260,7 @@ class DiscoveryPatterns(Command):
         tp_lib_path: str = parse_tp_lib(args.tp_lib)
         target_dir = Path(args.target_discovery)
         utils.check_target_dir(target_dir)
+        cpg_name: str = args.cpg_existing
         output_dir: str = parse_output_dir(args.output_dir)
         tool_parsed: list[Dict] = parse_tool_list(args.tools)
         l_pattern_id = parse_patterns(args.all_patterns, args.pattern_range, args.patterns,
@@ -261,7 +268,7 @@ class DiscoveryPatterns(Command):
                                       language)
         try:
             interface.run_discovery_for_pattern_list(target_dir, l_pattern_id, language, tool_parsed, tp_lib_path,
-                                                     output_dir=output_dir, ignore=args.ignore)
+                                                     output_dir=output_dir, ignore=args.ignore, cpg=cpg_name)
         except InvalidSastTools:
             print(invalidSastTools())
             exit(1)

--- a/tp_framework/core/instance.py
+++ b/tp_framework/core/instance.py
@@ -222,7 +222,10 @@ def load_instance_from_metadata(metadata: str, tp_lib: Path, language: str) -> I
         raise InstanceDoesNotExists(ref_metadata=metadata_path.name)
 
     with open(metadata_path) as file:
-        instance: Dict = json.load(file)
+        try:
+            instance: Dict = json.load(file)
+        except Exception as e:
+            raise e
 
     pattern_id = utils.get_id_from_name(metadata_path.parent.parent.name)
     pattern, p_dir = get_pattern_by_pattern_id(language, pattern_id, tp_lib)


### PR DESCRIPTION
This PR addresses #65 and makes the following contributions:
- bumps Joern version to `v1.2.1`
- adds correct error handling to rule discovery
    - catch trying to load specified but non-existent instance metadata file
    - catch trying to execute specified but non-existent rule scala file
    - correctly handle any raised errors from `run_joern_discovery_rule` and `process_joern_discovery_rule_findings` in `run_and_process_discovery_rule`
- generate a json file with finding details (in addition to full csv with output for every rule to have a less noisy thing to look at)
- add option to pass pre-computed cpg instead of generating a new cpg for the specified target source directory:
```
tpframework discovery -l JS -a -i -t in/cpgs/ -c example_cpg.bin
```

Tested for Java and Javascript discovery.
