### PR TITLE
Joern Installation fix and CPG-Only Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 .pytest_cache
 venv
 tp_framework.egg-info/
+tp_framework/.metals/
+tp_framework/.vscode/
 coverage_html/
 .coverage
 htmlcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ COPY pytest.ini ${TPF_HOME}/pytest.ini
 COPY SAST/requirements.txt ${SAST_DIR}/requirements.txt
 COPY SAST/sast-config.yaml ${SAST_DIR}/sast-config.yaml
 
+ARG TESTS_DIR="qualitytests"
+COPY ${TESTS_DIR}/requirements.txt ${TPF_HOME}/${TESTS_DIR}/requirements.txt
+
 ARG REQUIREMENTS_FILE
 COPY ${REQUIREMENTS_FILE} ${TPF_HOME}/${REQUIREMENTS_FILE}
 RUN pip install -r ${TPF_HOME}/${REQUIREMENTS_FILE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,18 +36,13 @@ ARG REQUIREMENTS_FILE
 COPY ${REQUIREMENTS_FILE} ${TPF_HOME}/${REQUIREMENTS_FILE}
 RUN pip install -r ${TPF_HOME}/${REQUIREMENTS_FILE}
 
-ARG JOERN_VERSION="v1.1.1538"
+ARG JOERN_VERSION="v1.2.1"
 RUN echo ${JOERN_VERSION}
 COPY discovery ${DISCOVERY_HOME}
 RUN chmod +x ${DISCOVERY_HOME}/joern/joern-install.sh
-RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/ && ./joern-install.sh --version=v1.1.1538 --install-dir=/opt/joern'
-
-# install js2cpg
-# RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/js2cpg/; sbt stage'
-
+RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/ && ./joern-install.sh --version=v1.2.1 --install-dir=/opt/joern'
 
 # ADD HERE COMMANDS USEFUL FOR OTHER DOCKER-COMPOSE SERVICES
-#
 
 ENV PYTHONPATH "${PYTHONPATH}:${TPF_HOME}/tp_framework"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,18 +29,15 @@ COPY pytest.ini ${TPF_HOME}/pytest.ini
 COPY SAST/requirements.txt ${SAST_DIR}/requirements.txt
 COPY SAST/sast-config.yaml ${SAST_DIR}/sast-config.yaml
 
-ARG TESTS_DIR="qualitytests"
-COPY ${TESTS_DIR}/requirements.txt ${TPF_HOME}/${TESTS_DIR}/requirements.txt
-
 ARG REQUIREMENTS_FILE
 COPY ${REQUIREMENTS_FILE} ${TPF_HOME}/${REQUIREMENTS_FILE}
 RUN pip install -r ${TPF_HOME}/${REQUIREMENTS_FILE}
 
-ARG JOERN_VERSION="v1.2.1"
+ARG JOERN_VERSION="v1.1.1709"
 RUN echo ${JOERN_VERSION}
 COPY discovery ${DISCOVERY_HOME}
 RUN chmod +x ${DISCOVERY_HOME}/joern/joern-install.sh
-RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/ && ./joern-install.sh --version=v1.2.1 --install-dir=/opt/joern'
+RUN /bin/sh -c 'cd ${DISCOVERY_HOME}/joern/ && ./joern-install.sh --version=${JOERN_VERSION} --install-dir=/opt/joern --reinstall --without-plugins'
 
 # ADD HERE COMMANDS USEFUL FOR OTHER DOCKER-COMPOSE SERVICES
 

--- a/tp_framework/cli/interface.py
+++ b/tp_framework/cli/interface.py
@@ -63,7 +63,8 @@ def add_pattern(pattern_dir: str, language: str, measure: bool, tools: list[Dict
 def run_discovery_for_pattern_list(src_dir: Path, pattern_id_list: list[int], language: str, itools: list[Dict],
                                    tp_lib_path: Path = Path(config.DEFAULT_TP_LIBRARY_ROOT_DIR).resolve(),
                                    output_dir: Path = Path(config.RESULT_DIR).resolve(),
-                                   ignore: bool = False):
+                                   ignore: bool = False,
+                                   cpg: str = None):
     print("Discovery for patterns started...")
     # Set output directory and logger
     build_name, disc_output_dir = utils.get_operation_build_name_and_dir(
@@ -72,7 +73,7 @@ def run_discovery_for_pattern_list(src_dir: Path, pattern_id_list: list[int], la
     #
     utils.check_tp_lib(tp_lib_path)
     d_res = discovery.discovery(Path(src_dir), pattern_id_list, tp_lib_path, itools, language, build_name,
-                                disc_output_dir, ignore=ignore)
+                                disc_output_dir, ignore=ignore, cpg=cpg)
     print("Discovery for patterns completed.")
     print(f"- results available here: {disc_output_dir}")
     print(f"- log file available here: {disc_output_dir / config.logfile}")

--- a/tp_framework/cli/tpf_commands.py
+++ b/tp_framework/cli/tpf_commands.py
@@ -214,6 +214,12 @@ class DiscoveryPatterns(Command):
             help="Path to discovery target folder"
         )
         discovery_parser.add_argument(
+            "-c", "--cpg",
+            dest="cpg_existing",
+            type=str,
+            help="Specify an already existing CPG in TARGET_DIR instead of letting the framework generate a new one."
+        )
+        discovery_parser.add_argument(
             "-i", "--ignore-measurements",
             action="store_true",
             default=False,
@@ -254,6 +260,7 @@ class DiscoveryPatterns(Command):
         tp_lib_path: str = parse_tp_lib(args.tp_lib)
         target_dir = Path(args.target_discovery)
         utils.check_target_dir(target_dir)
+        cpg_name: str = args.cpg_existing
         output_dir: str = parse_output_dir(args.output_dir)
         tool_parsed: list[Dict] = parse_tool_list(args.tools)
         l_pattern_id = parse_patterns(args.all_patterns, args.pattern_range, args.patterns,
@@ -261,7 +268,7 @@ class DiscoveryPatterns(Command):
                                       language)
         try:
             interface.run_discovery_for_pattern_list(target_dir, l_pattern_id, language, tool_parsed, tp_lib_path,
-                                                     output_dir=output_dir, ignore=args.ignore)
+                                                     output_dir=output_dir, ignore=args.ignore, cpg=cpg_name)
         except InvalidSastTools:
             print(invalidSastTools())
             exit(1)

--- a/tp_framework/core/discovery.py
+++ b/tp_framework/core/discovery.py
@@ -500,7 +500,7 @@ def post_process_and_export_results(d_res: dict, build_name: str, disc_output_di
             continue
         for tpi_id in d_res[tp_id]["instances"]:
             tpi_data = d_res[tp_id]["instances"][tpi_id]
-            if not tpi_data:
+            if not tpi_data or tpi_data["instance"] is None:
                 rows.append(
                     {
                         "patternId": tp_id,
@@ -610,7 +610,8 @@ def get_unsuccessful_discovery_tpi_from_results(d_res):
             for tp_id in [tp_id for tp_id in d_res["results"] if d_res["results"][tp_id]['measurement_found'] is not False]
             for tpi_id in d_res["results"][tp_id]['instances']
             if d_res["results"][tp_id]['instances'][tpi_id]["measurement"] in ["not_supported", "ignored"] and
-            d_res["results"][tp_id]['instances'][tpi_id]["discovery"]["results"] is None]
+            (d_res["results"][tp_id]['instances'][tpi_id]["instance"] is None
+            or d_res["results"][tp_id]['instances'][tpi_id]["discovery"]["results"] is None)]
 
 
 def get_successful_discovery_tpi_from_results(d_res):
@@ -618,6 +619,7 @@ def get_successful_discovery_tpi_from_results(d_res):
             for tp_id in [tp_id for tp_id in d_res["results"] if d_res["results"][tp_id]['measurement_found'] is not False]
             for tpi_id in d_res["results"][tp_id]['instances']
             if d_res["results"][tp_id]['instances'][tpi_id]["measurement"] in ["not_supported", "ignored"] and
+            d_res["results"][tp_id]['instances'][tpi_id]["instance"] is not None and
             d_res["results"][tp_id]['instances'][tpi_id]["discovery"]["results"] is not None]
 
 
@@ -628,7 +630,9 @@ def get_num_discovery_findings_from_results(d_res):
             continue
         for tpi_id in d_res["results"][tp_id]['instances']:
             tpi_data = d_res["results"][tp_id]['instances'][tpi_id]
-            if tpi_data["measurement"] in ["not_supported", "ignored"]  and tpi_data["discovery"]["results"] is not None:
+            if (tpi_data["measurement"] in ["not_supported", "ignored"] 
+                and d_res["results"][tp_id]['instances'][tpi_id]["instance"] is not None
+                and tpi_data["discovery"]["results"] is not None):
                 for r in tpi_data["discovery"]["results"]:
                     if r["discovery"] == True:
                         n += 1

--- a/tp_framework/core/discovery.py
+++ b/tp_framework/core/discovery.py
@@ -245,18 +245,27 @@ def discovery(src_dir: Path, l_tp_id: list[int], tp_lib_path: Path, itools: list
               build_name: str,
               disc_output_dir: Path,
               timeout_sec: int = 0,
-              ignore=False) -> Dict:
+              ignore=False,
+              cpg: str = None) -> Dict:
     logger.info("Discovery for patterns started...")
     # TODO: to support multiple discovery methods the following would need major refactoring.
     # - CPG is specific to Joern
     # - each discovery rule tells which method to use
     # - on the other hand you do not want to compute the CPG multiple times
-    cpg: Path = generate_cpg(src_dir, language, build_name, disc_output_dir, timeout_sec=timeout_sec)
+
+    # if a CPG name is specified, expect it in TARGET_DIR. Else, generate new CPG from source
+    if cpg is not None:
+        cpg_path: Path = src_dir / cpg
+        if not cpg_path.exists():
+            logger.error(f"The specified CPG file {cpg_path} does not exist...")
+            raise FileNotFoundError
+    else:
+        cpg_path: Path = generate_cpg(src_dir, language, build_name, disc_output_dir, timeout_sec=timeout_sec)
     if not ignore:
-        return discovery_under_measurement(cpg, l_tp_id, tp_lib_path, itools, language, build_name, disc_output_dir,
+        return discovery_under_measurement(cpg_path, l_tp_id, tp_lib_path, itools, language, build_name, disc_output_dir,
                                            timeout_sec=timeout_sec)
     else:
-        return discovery_ignore_measurement(cpg, l_tp_id, tp_lib_path, language, build_name, disc_output_dir,
+        return discovery_ignore_measurement(cpg_path, l_tp_id, tp_lib_path, language, build_name, disc_output_dir,
                                             timeout_sec=timeout_sec)
 
 
@@ -389,7 +398,15 @@ def discovery_ignore_measurement(cpg: Path, l_tp_id: list[int], tp_lib: Path,
         for tpi_id in d_tpi_id_path:
             tpi_json_path = d_tpi_id_path[tpi_id]
             tpi_json_rel = os.path.relpath(tpi_json_path, start=tp_lib)
-            tpi_instance = load_instance_from_json(tpi_json_rel, tp_lib, language)  # get the instance # TODO: this ingores the language
+            # get the instance
+            try:
+                tpi_instance = load_instance_from_json(tpi_json_rel, tp_lib, language)  # TODO: this ignores the language
+            except:
+                # instance for which no discovery could be done as instance not properly loaded
+                logger.exception(f"Failed to decode the metadata associated to the instance `{tpi_json_rel}`...")
+                d_tpi = {"instance": None, "measurement": "ignored", "jsonpath": None}
+                d_res_tpi[tpi_id] = d_tpi
+                continue
             d_tpi = {"instance": tpi_instance, "measurement": "ignored", "jsonpath": tpi_json_path,
                      "discovery": discovery_for_tpi(tpi_instance, tpi_json_path, cpg, disc_output_dir,
                                                     measurement_stop=False, already_executed=d_dr_executed)}
@@ -412,6 +429,11 @@ def discovery_for_tpi(tpi_instance: Instance, tpi_json_path: Path, cpg: Path, di
     if not measurement_stop and tpi_instance.discovery_rule:
         # prepare and execute the discovery rule (if not done yet)
         dr = (tpi_json_path.parent / tpi_instance.discovery_rule).resolve()
+        if not dr.exists():
+            d_tpi_discovery["rule_path"] = str(dr)
+            logger.error(f"{msgpre}Discovery rule is specified in the instance, but corresponding file {dr} does not exists...")
+            return d_tpi_discovery
+
         logger.info(
             f"{msgpre}prepare discovery rule {dr}...")
         d_tpi_discovery["rule_path"] = str(dr)
@@ -423,18 +445,16 @@ def discovery_for_tpi(tpi_instance: Instance, tpi_json_path: Path, cpg: Path, di
                 f"{msgpre}running discovery rule...")
             # related to #42
             pdr = patch_PHP_discovery_rule(dr, tpi_instance.language, output_dir=disc_output_dir)
-            #
             try:
                 findings = run_and_process_discovery_rule(cpg, pdr, discovery_method=d_tpi_discovery["method"])
                 d_tpi_discovery["results"] = findings
                 d_tpi_discovery["rule_already_executed"] = False
-            except DiscoveryMethodNotSupported as e:
+            except Exception as e:
                 d_tpi_discovery["results"] = None
                 already_executed[d_tpi_discovery["rule_hash"]] = None
                 logger.error(
                     f"{msgpre}Discovery rule failure for this instance: {e}")
-                ## JoernQueryError(e)
-            ## JoernQueryParsingResultError(e)
+            # except DiscoveryMethodNotSupported, JoernQueryError(e), JoernQueryParsingResultError(e):
             already_executed[d_tpi_discovery["rule_hash"]] = findings
             logger.info(
                 f"{msgpre} discovery rule executed.")
@@ -447,7 +467,7 @@ def discovery_for_tpi(tpi_instance: Instance, tpi_json_path: Path, cpg: Path, di
     else:
         # no rule to execute
         logger.warning(
-            f"{msgpre}No discovery rule for this pattern instance...")
+            f"{msgpre}No discovery rule specified for this pattern instance...")
     return d_tpi_discovery
 
 
@@ -457,6 +477,7 @@ def post_process_and_export_results(d_res: dict, build_name: str, disc_output_di
               "method", "queryFile", "queryHash", "queryName", "queryAccuracy",
               "queryAlreadyExecuted", "discovery", "filename", "lineNumber", "methodFullName"]
     rows = []
+    findings = []
     for tp_id in d_res:
         if d_res[tp_id]["measurement_found"] is False:
             rows.append(
@@ -479,7 +500,26 @@ def post_process_and_export_results(d_res: dict, build_name: str, disc_output_di
             continue
         for tpi_id in d_res[tp_id]["instances"]:
             tpi_data = d_res[tp_id]["instances"][tpi_id]
-            if tpi_data["measurement"] not in ["not_supported", "ignored"]:
+            if not tpi_data:
+                rows.append(
+                    {
+                        "patternId": tp_id,
+                        "instanceId": tpi_id,
+                        "instanceName": None,
+                        "sast_measurement": None,
+                        "method": None,
+                        "queryFile": None,
+                        "queryHash": None,
+                        "queryName": None,
+                        "queryAccuracy": None,
+                        "queryAlreadyExecuted": None,
+                        "discovery": None,
+                        "filename": None,
+                        "lineNumber": None,
+                        "methodFullName": None
+                    })
+                continue
+            elif tpi_data["measurement"] not in ["not_supported", "ignored"]:
                 rows.append(
                     {
                         "patternId": tp_id,
@@ -526,6 +566,7 @@ def post_process_and_export_results(d_res: dict, build_name: str, disc_output_di
                             row["discovery"] = f["discovery"]
                             row["queryName"] = f["queryName"]
                             if f["discovery"]:
+                                findings.append(f)
                                 row["filename"] = f["filename"]
                                 row["lineNumber"] = f["lineNumber"]
                                 row["methodFullName"] = f["methodFullName"]
@@ -535,6 +576,9 @@ def post_process_and_export_results(d_res: dict, build_name: str, disc_output_di
                             pass
     ofile = disc_output_dir / f"discovery_{build_name}.csv"
     utils.write_csv_file(ofile, fields, rows)
+    findings_file = disc_output_dir / f"findings_{build_name}.json"
+    with open(findings_file, 'w+') as f:
+        json.dump(findings, f, sort_keys=True, indent=4)
     d_results = {
         "discovery_result_file": str(ofile),
         "results": d_res

--- a/tp_framework/core/discovery.py
+++ b/tp_framework/core/discovery.py
@@ -449,13 +449,13 @@ def discovery_for_tpi(tpi_instance: Instance, tpi_json_path: Path, cpg: Path, di
                 findings = run_and_process_discovery_rule(cpg, pdr, discovery_method=d_tpi_discovery["method"])
                 d_tpi_discovery["results"] = findings
                 d_tpi_discovery["rule_already_executed"] = False
+                already_executed[d_tpi_discovery["rule_hash"]] = findings
             except Exception as e:
                 d_tpi_discovery["results"] = None
                 already_executed[d_tpi_discovery["rule_hash"]] = None
                 logger.error(
                     f"{msgpre}Discovery rule failure for this instance: {e}")
             # except DiscoveryMethodNotSupported, JoernQueryError(e), JoernQueryParsingResultError(e):
-            already_executed[d_tpi_discovery["rule_hash"]] = findings
             logger.info(
                 f"{msgpre} discovery rule executed.")
 

--- a/tp_framework/core/utils.py
+++ b/tp_framework/core/utils.py
@@ -67,7 +67,7 @@ def get_instance_dir_from_id(instance_id: int, pattern_dir: Path) -> Path:
 def get_instance_dir_from_list(instance_id: int, l_pattern_dir: list[Path]):
     instance_with_id = list(filter(lambda tpi_dir: get_id_from_name(tpi_dir.name) == instance_id, l_pattern_dir))
     if not instance_with_id:
-        raise InstanceDoesNotExists()
+        raise InstanceDoesNotExists(instance_id=instance_id)
     return instance_with_id[0]
 
 # def get_or_create_language_dir(language: str, tp_lib_dir: Path) -> Path:


### PR DESCRIPTION
This PR builds upon https://github.com/testable-eu/sast-tp-framework/pull/66.

Changes:
- pins Joern to version v1.1.1709
    - I found a rule breaking for versions > v1.2.x and v2.x introduces multiple breaking changes
    - this version is relatively well tested
- correctly catches empty `instances` in `post_process_and_export_results` et al.
    - because of an exception block in `discovery_ignore_measurement`, entries in the `d_results` could be non-None but have a None `instance` field, missing the required `discovery` field. This was not handled correctly before.
- remove the `requirements.txt` for `qualitytests` from the docker image. For non-dev builds, this file was included but never used.
- adds correct error handling to rule discovery
    - catch trying to load specified but non-existent instance metadata file
    - catch trying to execute specified but non-existent rule scala file
    - correctly handle any raised errors from `run_joern_discovery_rule` and `process_joern_discovery_rule_findings` in `run_and_process_discovery_rule`
- generate a json file with finding details (in addition to full csv with output for every rule to have a less noisy thing to look at)
- add option to pass pre-computed cpg instead of generating a new cpg for the specified target source directory:
`tpframework discovery -l JS -a -i -t in/cpgs/ -c example_cpg.bin`

Tested for Java and Javascript discovery.

Please feel free to test @compaluca @felix-20 @mlessio 